### PR TITLE
WILL-989/Bugfix: Crash when SM API was down

### DIFF
--- a/src/Exceptions/SiteNotFoundException.php
+++ b/src/Exceptions/SiteNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bonnier\WP\SiteManager\Exceptions;
+
+use Exception;
+
+/**
+ * Class SiteNotFoundException
+ *
+ * @package \\${NAMESPACE}
+ */
+class SiteNotFoundException extends Exception
+{
+}

--- a/src/Repositories/SiteRepository.php
+++ b/src/Repositories/SiteRepository.php
@@ -5,6 +5,7 @@ namespace Bonnier\WP\SiteManager\Repositories;
 use Bonnier\WP\SiteManager\Http\SiteManagerClient;
 use Bonnier\WP\SiteManager\Contracts\SiteContract;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 
 /**
  * Class SiteRepository
@@ -49,6 +50,8 @@ class SiteRepository implements SiteContract
         try {
             $response = $this->siteManagerClient->get('/api/v1/sites/'.$siteId);
         } catch (ClientException $e) {
+            return null;
+        } catch (ServerException $e) {
             return null;
         }
         return $response->getStatusCode() === 200 ?

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -5,7 +5,7 @@ namespace Bonnier\WP\SiteManager\Services;
 abstract class BaseService
 {
     // Cache expire time (in sec)
-    const SITEMANAGER_CACHE_EXPIRE = "1800";
+    const SITEMANAGER_CACHE_EXPIRE = "3200";
     // Cache group
     const SITEMANAGER_CACHE_GROUP = "bonnier-wp-sitemanager";
 

--- a/wp-site-manager.php
+++ b/wp-site-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Site Manager
  * Plugin URI: http://bonnierpublications.com
  * Description: Service for the site manager
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Michael Sørensen & Frederik Rabøl
  * Author URI: http://bonnierpublications.com
  */


### PR DESCRIPTION
- Changed site repository to use transient cache instead of object cache
- Improved caching of sites fetched by id, so even if the SM API respons with error the site will still be returned, so long as the cache has been populated before
- Added catch of server errors from SiteManager API
- Added new SiteNotFoundException to better illustrate problems fetching sites